### PR TITLE
Fix: Limit LayoutPath override to packages of Neos/Neos

### DIFF
--- a/Configuration/Views.yaml
+++ b/Configuration/Views.yaml
@@ -1,5 +1,5 @@
 -
-  requestFilter: 'parentRequest.isPackage("Neos.Neos") && parentRequest.isController("Backend\Module") && isFormat("html") && !isPackage("Neos.Media.Browser") && !isController("Module\Management\History")'
+  requestFilter: 'isPackage("Neos.Neos") && parentRequest.isController("Backend\Module") && isFormat("html") && !isPackage("Neos.Media.Browser") && !isController("Module\Management\History")'
   options:
     layoutRootPaths:
       'Unikka.LoginAs': 'resource://Unikka.LoginAs/Private/Layouts'


### PR DESCRIPTION
To prevent exceptions in third party modules we limit the override of the layoutRootPaths to the
Neos/Neos backend modules

re #9
