### PR TITLE
Update ImpersonateService.php

### DIFF
--- a/Classes/Service/ImpersonateService.php
+++ b/Classes/Service/ImpersonateService.php
@@ -169,7 +169,7 @@ class ImpersonateService
      * @param string $key
      * @throws SessionNotStartedException
      */
-    protected function getSessionData(string $key): mixed
+    protected function getSessionData(string $key): ?mixed
     {
         return $this->session->isStarted() && $this->session->hasKey($key) ? $this->session->getData($key) : null;
     }


### PR DESCRIPTION
return value of getSessionData() can also be null, the return type mixed does not cover this in PHP7

fixes Issue https://github.com/Unikka/login-as/issues/20