### PR TITLE
Fix: Remove mixed type

### DIFF
--- a/Classes/Service/ImpersonateService.php
+++ b/Classes/Service/ImpersonateService.php
@@ -169,7 +169,7 @@ class ImpersonateService
      * @param string $key
      * @throws SessionNotStartedException
      */
-    protected function getSessionData(string $key): ?mixed
+    protected function getSessionData(string $key)
     {
         return $this->session->isStarted() && $this->session->hasKey($key) ? $this->session->getData($key) : null;
     }


### PR DESCRIPTION
Sorry, I made a mistake there, in PHP7 the mixed type doesn't even exist.
So we need to omit the return type altogether here to maintain compatibility for projects on Neos7 / PHP7